### PR TITLE
Update README for ES6, examples and formatting. Resolves #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,77 +2,82 @@
 
 Class to localize the ReactNative interface
 
-###What
+## What it does
+
 I just needed a dead simple way to internationalize my first React Native app.
 
 At the beginning I thought I'd expose the native iOS internationalization API (NSLocalizedString macro) to Native Script, but then I've opted for a solution that seems, at least to me, more in the spirit of React (and I hope better performance wise).
 
 In this implementation we can keep the localized strings in the same file of the React View in a similar way of how Styles are implemented (I don't deny that this approach could lead to some duplications in the translated strings, but it could be feasable to create a commonjs module to use as common source of the strings, requiring it in the different views).
 
-###How it works
-  The Javascript library uses a native library (ReactLocalization) to get the current interface language,
-  then it loads and displays the strings matching the current interface locale or the default language (the first one if a match is not found) if a specific localization can't be found.
+## How it works
 
-  It's possible to force a language different from the interface one.
+The Javascript library uses a native library (ReactLocalization) to get the current interface language, then it loads and displays the strings matching the current interface locale or the default language (the first one if a match is not found) if a specific localization can't be found.
 
-###Installation
-  1. `npm install react-native-localization`
-  2. In the XCode's "Project navigator", right click on Libraries folder under your project ➜ `Add Files to <...>`
-  3. Go to `node_modules` ➜ `react-native-localization` and add the project
-      * ReactNativeLocalization.xcodeproj
-  4. Add libReactNativeLocalization.a to Build Phases -> Link Binary With Libraries    
-  5. Build and run
+It's possible to force a language different from the interface one.
 
-###How to use:
+## Installation
 
-  1. in the React class that you want to localize require the library and define
-     the strings object passing to the constructor a simple object containing
-     a language key (i.e. en, it, fr..) and then a list of key-value pairs with
-     the needed localized strings
+1. `npm install --save react-native-localization`
+2. In the XCode's "Project navigator", right click on Libraries folder under your project ➜ `Add Files to <...>`
+3. Go to `node_modules` ➜ `react-native-localization` and add the `ReactNativeLocalization.xcodeproj` file
+4. Add libReactNativeLocalization.a to Build Phases -> Link Binary With Libraries
+5. Build and run
 
- ```javascript
- var LocalizedStrings = require('./node_modules/react-native-localization/LocalizedStrings');
-;
+## Usage
 
- var strings = new  LocalizedStrings({
-    en:{
-      how:"How do you want your egg today?",
-      boiledEgg:"Boiled egg",
-      softBoiledEgg:"Soft-boiled egg",
-      choice:"How to choose the egg"
-    },
-    it:{
-      how:"Come vuoi il tuo uovo oggi?",
-      boiledEgg:"Uovo sodo",
-      softBoiledEgg:"Uovo alla coque",
-      choice:"Come scegliere l'uovo"
-    }
- });
- ```
+In the React class that you want to localize require the library and define the strings object passing to the constructor a simple object containing a language key (i.e. en, it, fr..) and then a list of key-value pairs with the needed localized strings.
 
-  2. Use the strings object directly in the render method accessing the key
-     of the localized string
+ ```js
+import LocalizedStrings from 'react-native-localization';
 
-  ```javascript
-  <Text style={styles.title}>
-    {strings.how}
-  </Text>
-  ```
+let localizedStrings = new LocalizedStrings({
+  en:{
+    how:"How do you want your egg today?",
+    boiledEgg:"Boiled egg",
+    softBoiledEgg:"Soft-boiled egg",
+    choice:"How to choose the egg"
+  },
+  it: {
+    how:"Come vuoi il tuo uovo oggi?",
+    boiledEgg:"Uovo sodo",
+    softBoiledEgg:"Uovo alla coque",
+    choice:"Come scegliere l'uovo"
+  }
+});
+```
 
-###Other methods
+Then use the `localizedStrings` object literal directly in the render method accessing the key of the localized string.
+
+```js
+<Text style={styles.title}>
+  {strings.how}
+</Text>
+```
+
+## API
 
 * setLanguage(languageCode) - to force manually a particular language
 * getLanguage() - to get the current displayed language
 * getInterfaceLanguage() - to get the current device interface language
 
-###Other examples
+## Examples
 To force a particular language use something like this:
-```javascript
-  _onSetLanguageToItalian(){
-    strings.setLanguage('it');
-    this.setState({});
-  }
+
+```js
+_onSetLanguageToItalian() {
+  strings.setLanguage('it');
+  this.setState({});
+}
 ```
 
+It's also possible to set the language directly in your Xcode project using the following code snippet:
+
+```objective-c
+[[NSUserDefaults standardUserDefaults] setObject:[NSArray arrayWithObjects:@"de", nil] forKey:@"AppleLanguages"];
+```
+
+Replace `de` with a [supported locale identifier](https://gist.github.com/pjc-is/49971b36db38fdeae6fc) to test.
+
 ## Questions or suggestions?
-Feel free to contact me in [twitter](https://twitter.com/talpaz) or [create an issue](https://github.com/stefalda/ReactNativeLocalization/issues/new)
+Feel free to contact me on [Twitter](https://twitter.com/talpaz) or [open an issue](https://github.com/stefalda/ReactNativeLocalization/issues/new).


### PR DESCRIPTION
ES6 is an approved spec. Let's help people forget `require` syntax ever existed.