### PR TITLE
Require NativeModules via React Native package

### DIFF
--- a/LocalizedStrings.js
+++ b/LocalizedStrings.js
@@ -43,7 +43,7 @@
 'use strict';
 
 //var Q = require("q");
-var localization = require('NativeModules').ReactLocalization;
+var localization = require('react-native').NativeModules.ReactLocalization;
 var interfaceLanguage = localization.language;
 
 class LocalizedStrings{


### PR DESCRIPTION
As of RN v0.7.0 all require statements for React Native modules should
go through the public interface. This patch suppresses the warning when
building the package and ensures the library won’t break in the future.