### PR TITLE
Fix for language strings with multiple tags

### DIFF
--- a/LocalizedStrings.js
+++ b/LocalizedStrings.js
@@ -20,11 +20,12 @@ class LocalizedStrings{
   _getBestMatchingLanguage(language, props){
     //If an object with the passed language key exists return it
     if (props[language]) return language;
-    //if the string is composed try to find a match with only the first language identifiers (en-US --> en)
-    let idx = language.indexOf("-");
+    //if the string is multiple tags, try to match without the final tag
+    //(en-US --> en, zh-Hans-CN --> zh-Hans)
+    let idx = language.lastIndexOf("-");
     if (idx>=0) {
       language = language.substring(0,idx);
-      if (props[language]) return language;
+      return this._getBestMatchingLanguage(language, props)
     }
     //Return the default language (the first coded)
     return Object.keys(props)[0];


### PR DESCRIPTION
These may identify scripts, regions, etc.
For example, `zh-Hans-CN` now tries to match `zh-Hans` instead of just `zh`.