### PR TITLE
fully return region locale form android and replace '_' with '-'

### DIFF
--- a/LocalizedStrings.js
+++ b/LocalizedStrings.js
@@ -14,7 +14,7 @@
 'use strict';
 
 var localization = require('react-native').NativeModules.ReactLocalization;
-var interfaceLanguage = localization.language;
+var interfaceLanguage = localization.language.replace(/_/g,'-');
 class LocalizedStrings{
 
   _getBestMatchingLanguage(language, props){

--- a/android/src/main/java/com/babisoft/ReactNativeLocalization/ReactNativeLocalization.java
+++ b/android/src/main/java/com/babisoft/ReactNativeLocalization/ReactNativeLocalization.java
@@ -36,7 +36,7 @@ public class ReactNativeLocalization extends ReactContextBaseJavaModule{
      */
     private String getCurrentLanguage(){
         Locale current =  getReactApplicationContext().getResources().getConfiguration().locale;
-        return current.getLanguage();
+        return current.toString();
     }
 
     /**


### PR DESCRIPTION
android should return full string including region modifier.
(ex: zh_TW instead of zh)
And also replace underline with dash to be consistent with iOS.
