### PR TITLE
Add .podspec for CocoaPods in iOS projects

### DIFF
--- a/ReactNativeLocalization.podspec
+++ b/ReactNativeLocalization.podspec
@@ -1,0 +1,23 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name                = 'ReactNativeLocalization'
+  s.version             = package['version']
+  s.summary             = package['description']
+  s.description         = package['description']
+  s.homepage            = package['homepage']
+  s.license             = package['license']
+  s.author              = package['author']
+  s.source              = { :git => 'https://github.com/stefalda/ReactNativeLocalization.git', :tag => 'v'+s.version.to_s }
+
+  s.platform              = :ios, '9.0'
+  s.ios.deployment_target = '8.0'
+
+  s.dependency 'React'
+
+  s.preserve_paths      = 'CHANGELOG.md', 'LICENSE', 'package.json', 'LocalizedStrings.js'
+  s.source_files        = '**/*.{h,m}'
+  s.exclude_files       = 'android/**/*'
+end


### PR DESCRIPTION
Pretty simple but nice to have :)

pod lib lint does not work out of the box since the 'React' dependency is local.

```
Roberts-MBP:ios Robert$ pod install
Analyzing dependencies
Fetching podspec for `React` from `../node_modules/react-native/`
Fetching podspec for `ReactNativeLocalization` from `../node_modules/react-native-localization/`
Downloading dependencies
Using React (0.32.0)
Installing ReactNativeLocalization (0.1.17)
Generating Pods project
Integrating client project
Sending stats
Pod installation complete! There are 12 dependencies from the Podfile and 5 total pods installed.
```