### PR TITLE
Adds country code for Android

### DIFF
--- a/android/src/main/java/com/babisoft/ReactNativeLocalization/ReactNativeLocalization.java
+++ b/android/src/main/java/com/babisoft/ReactNativeLocalization/ReactNativeLocalization.java
@@ -35,7 +35,7 @@ public class ReactNativeLocalization extends ReactContextBaseJavaModule {
      */
     private String getCurrentLanguage() {
         Locale current = getReactApplicationContext().getResources().getConfiguration().locale;
-        return current.toString();
+        return current.getLanguage() + "-" + current.getCountry();
     }
 
     /**


### PR DESCRIPTION
`getCurrentLanguage` now returns languages in the format "xx-XX" where the first two 'x's are the language code and the second two are the country code.
This brings Android in line with iOS and ensures that language variants such as simplified or traditional Chinese aren't lost between the native app side and the react side.