### PR TITLE
Update LocalizedStrings.js

### DIFF
--- a/LocalizedStrings.js
+++ b/LocalizedStrings.js
@@ -13,8 +13,8 @@
  */
 'use strict';
 
-var localization = require('react-native').NativeModules.ReactLocalization;
-var interfaceLanguage = localization.language.replace(/_/g,'-');
+var localization = require('react-native').NativeModules.I18nManager;
+var interfaceLanguage = localization.localeIdentifier.replace(/_/g,'-');
 class LocalizedStrings{
 
   _getBestMatchingLanguage(language, props){


### PR DESCRIPTION
NativeModules.ReactLocalization doesn't exist So I have updated the package for using I18nManager instead.
Now you get languages like "en-US" or "es-ES". You have to take that into account when your create your language configuration object.