### PR TITLE
Add typescript typings file

### DIFF
--- a/lib/LocalizedStrings.d.ts
+++ b/lib/LocalizedStrings.d.ts
@@ -1,0 +1,17 @@
+declare class LocalizedStrings {
+  // Indexer
+  [key: string]: string | ( (...args: any[]) => any );
+
+  constructor(props: { [language: string]: { [key: string]: string }});
+  getLanguage(): string;
+  setLanguage(language: string): void;
+  getInterfaceLanguage(): string;
+  getAvailableLanguages(): string[];
+  formatString(str: string, ...values: string[]): string;
+  getString(key: string, language: string): string;
+}
+
+declare module 'react-native-localization' {
+	export = LocalizedStrings;
+}
+


### PR DESCRIPTION
Add typescript typings for (what I assume) are public functions (i.e. not the functions prefixed with ```_```)