### PR TITLE
Change headers for react-native 0.40 compatibility

### DIFF
--- a/ReactLocalization.h
+++ b/ReactLocalization.h
@@ -23,8 +23,13 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIDevice.h>
+#if __has_include("RCTBridgeModule.h")
 #import "RCTBridgeModule.h"
 #import "RCTLog.h"
+#else
+#import <React/RCTBridgeModule.h>
+#import <React/RCTLog.h>
+#endif
 @interface ReactLocalization : NSObject<RCTBridgeModule>
 
 @end


### PR DESCRIPTION
This pull request adds compatibility with react-native 0.40 while keeping backwards compatibility with older versions.   
The breaking changes were announced here https://github.com/facebook/react-native/releases/tag/v0.40.0  
Backwards compatibilty solution was founded here https://medium.com/@thisismissem/how-to-upgrade-react-native-modules-in-a-backwards-compatible-manner-a5b5c48d590c#.u4m6ktkex