### PR TITLE
Fix non-default language used for missing strings

### DIFF
--- a/LocalizedStrings.js
+++ b/LocalizedStrings.js
@@ -73,7 +73,7 @@ class LocalizedStrings{
   //Load fallback values for missing translations 
     _fallbackValues(defaultStrings, strings){
     for (var key in defaultStrings){
-        if (defaultStrings.hasOwnProperty(key) && !strings[key]) {
+      if (defaultStrings.hasOwnProperty(key) && (!strings[key] || (strings.props[strings.language][key] !== strings[key]))) {
             strings[key]=defaultStrings[key];
             console.log("Missing localization for language '"+this.language+"' and key '"+key+"'.");
         }


### PR DESCRIPTION
Non-default language is supposed to be used when a string is missing in
the current language.
Before the fix the ‘previously used’ language was used instead of the
default one.