### PR TITLE
Changed the definitiosn to get the following benefits:

### DIFF
--- a/lib/LocalizedStrings.d.ts
+++ b/lib/LocalizedStrings.d.ts
@@ -1,17 +1,68 @@
-declare class LocalizedStrings {
-  // Indexer
-  [key: string]: string | ( (...args: any[]) => any );
-
-  constructor(props: { [language: string]: { [key: string]: string }});
-  getLanguage(): string;
-  setLanguage(language: string): void;
-  getInterfaceLanguage(): string;
-  getAvailableLanguages(): string[];
-  formatString(str: string, ...values: string[]): string;
-  getString(key: string, language: string): string;
-}
-
 declare module 'react-native-localization' {
-	export = LocalizedStrings;
-}
 
+    namespace ReactNativeLocalization {
+        //
+        // Use this interface for casting the LocalizedString class in order to call
+        // one of the supported APIs. For example:
+        //
+        // var strings = LocalizedStrings({ "en": { "Hello": "Hello" }})
+        //
+        //  (strings as LocalizationApi).getLanguage()
+        //
+        export interface LocalizationStringsApi {
+            getLanguage(): string;
+
+            setLanguage(language: string): void;
+
+            getInterfaceLanguage(): string;
+
+            getAvailableLanguages(): string[];
+
+            formatString(str: string, ...values: string[]): string;
+
+            getString(key: string, language: string): string;
+        }
+
+        // Define input strings:
+        //
+        //  for example:
+        //
+        //  import LocalizedStrings, {LocalizationStringsApi, GlobalStrings> from 'react-native-localization'
+        //
+        //  interface MyStrings {
+        //      hello: string;
+        //      world: string;
+        //  }
+        //
+        //  The strings in English and french
+        //
+        //  const myGlobalStrings: GlobalStrings<MyStrings> {
+        //      "en": {
+        //          hello: "Hello",
+        //          world: "World"
+        //      },
+        //      "fr": {
+        //          hello: "Bonjour",
+        //          world: "le monde"
+        //      }
+        //
+        interface GlobalStrings<T> {
+            [language: string]: T;
+        }
+
+        // To get a localized version
+        //
+        // export default new LocalizedStrings(myGlobalStrings) as any as LocalizationStringsApi & MyStrings
+        //
+        // The reason for the above kludge is the fact that the exported strings is a type that is both
+        // my strings in adition to the functions exposed by the localizedStrings class
+        //
+        export default class LocalizedStrings<T>  {
+            constructor(globalStrings: GlobalStrings<T>);
+
+            [key: string]: string;
+        }
+    }
+
+    export = ReactNativeLocalization;
+}


### PR DESCRIPTION
1. You can define an interface with the string names. This will:
     a. Provide better auto-complete (with your string names)
     b. If you do not define a string as optional, you will get a compile
        error if you forget to include it in one or more language

2. The property of the LocalizedStrings class is a string (and not string|function)
   as it was before, so it can direcly be assigned to a string (the previous
   version caused a compile error since string|function can not be assigned to string