### PR TITLE
Better Types Declarations

### DIFF
--- a/lib/LocalizedStrings.d.ts
+++ b/lib/LocalizedStrings.d.ts
@@ -2,12 +2,9 @@ declare module 'react-native-localization' {
 
     namespace ReactNativeLocalization {
         //
-        // Use this interface for casting the LocalizedString class in order to call
-        // one of the supported APIs. For example:
-        //
         // var strings = LocalizedStrings({ "en": { "Hello": "Hello" }})
         //
-        //  (strings as LocalizationApi).getLanguage()
+        // strings.getLanguage()
         //
         export interface LocalizationStringsApi {
             getLanguage(): string;
@@ -27,7 +24,7 @@ declare module 'react-native-localization' {
         //
         //  for example:
         //
-        //  import LocalizedStrings, {LocalizationStringsApi, GlobalStrings> from 'react-native-localization'
+        //  import LocalizedStrings, {LocalizationStringsApi, GlobalStrings} from 'react-native-localization'
         //
         //  interface MyStrings {
         //      hello: string;
@@ -36,7 +33,7 @@ declare module 'react-native-localization' {
         //
         //  The strings in English and french
         //
-        //  const myGlobalStrings: GlobalStrings<MyStrings> {
+        //  const myGlobalStrings: GlobalStrings<MyStrings> = {
         //      "en": {
         //          hello: "Hello",
         //          world: "World"
@@ -45,7 +42,7 @@ declare module 'react-native-localization' {
         //          hello: "Bonjour",
         //          world: "le monde"
         //      }
-        //
+        //  }
         interface GlobalStrings<T> {
             [language: string]: T;
         }
@@ -57,10 +54,8 @@ declare module 'react-native-localization' {
         // The reason for the above kludge is the fact that the exported strings is a type that is both
         // my strings in adition to the functions exposed by the localizedStrings class
         //
-        export default class LocalizedStrings<T>  {
-            constructor(globalStrings: GlobalStrings<T>);
-
-            [key: string]: any;
+        export default interface LocalizedStrings {
+            new<T>(globalStrings: GlobalStrings<T>): LocalizationStringsApi & GlobalStrings<T>;
         }
     }
 

--- a/lib/LocalizedStrings.d.ts
+++ b/lib/LocalizedStrings.d.ts
@@ -1,63 +1,60 @@
 declare module 'react-native-localization' {
+    //
+    // var strings = LocalizedStrings({ "en": { "Hello": "Hello" }})
+    //
+    // strings.getLanguage()
+    //
+    export interface LocalizationStringsApi {
+        getLanguage(): string;
 
-    namespace ReactNativeLocalization {
-        //
-        // var strings = LocalizedStrings({ "en": { "Hello": "Hello" }})
-        //
-        // strings.getLanguage()
-        //
-        export interface LocalizationStringsApi {
-            getLanguage(): string;
+        setLanguage(language: string): void;
 
-            setLanguage(language: string): void;
+        getInterfaceLanguage(): string;
 
-            getInterfaceLanguage(): string;
+        getAvailableLanguages(): string[];
 
-            getAvailableLanguages(): string[];
+        formatString(str: string, ...values: string[]): string;
 
-            formatString(str: string, ...values: string[]): string;
-
-            getString(key: string, language: string): string;
-        }
-
-        // Define input strings:
-        //
-        //  for example:
-        //
-        //  import LocalizedStrings, {LocalizationStringsApi, GlobalStrings} from 'react-native-localization'
-        //
-        //  interface MyStrings {
-        //      hello: string;
-        //      world: string;
-        //  }
-        //
-        //  The strings in English and french
-        //
-        //  const myGlobalStrings: GlobalStrings<MyStrings> = {
-        //      "en": {
-        //          hello: "Hello",
-        //          world: "World"
-        //      },
-        //      "fr": {
-        //          hello: "Bonjour",
-        //          world: "le monde"
-        //      }
-        //  }
-        interface GlobalStrings<T> {
-            [language: string]: T;
-        }
-
-        // To get a localized version
-        //
-        // export default new LocalizedStrings(myGlobalStrings) as any as LocalizationStringsApi & MyStrings
-        //
-        // The reason for the above kludge is the fact that the exported strings is a type that is both
-        // my strings in adition to the functions exposed by the localizedStrings class
-        //
-        export default interface LocalizedStrings {
-            new<T>(globalStrings: GlobalStrings<T>): LocalizationStringsApi & GlobalStrings<T>;
-        }
+        getString(key: string, language: string): string;
     }
 
-    export = ReactNativeLocalization;
+    // Define input strings:
+    //
+    //  for example:
+    //
+    //  import LocalizedStrings, {LocalizationStringsApi, GlobalStrings} from 'react-native-localization'
+    //
+    //  interface MyStrings {
+    //      hello: string;
+    //      world: string;
+    //  }
+    //
+    //  The strings in English and french
+    //
+    //  const myGlobalStrings: GlobalStrings<MyStrings> = {
+    //      "en": {
+    //          hello: "Hello",
+    //          world: "World"
+    //      },
+    //      "fr": {
+    //          hello: "Bonjour",
+    //          world: "le monde"
+    //      }
+    //  }
+    interface GlobalStrings<T> {
+        [language: string]: T;
+    }
+
+    // To get a localized version
+    //
+    // export default new LocalizedStrings(myGlobalStrings) as any as LocalizationStringsApi & MyStrings
+    //
+    // The reason for the above kludge is the fact that the exported strings is a type that is both
+    // my strings in adition to the functions exposed by the localizedStrings class
+    //
+    interface ILocalizedStrings {
+        new<T>(globalStrings: GlobalStrings<T>): LocalizationStringsApi & T;
+    }
+    const LocalizedStrings: ILocalizedStrings;
+    export default LocalizedStrings;
 }

--- a/lib/LocalizedStrings.d.ts
+++ b/lib/LocalizedStrings.d.ts
@@ -4,7 +4,7 @@ declare module 'react-native-localization' {
     //
     // strings.getLanguage()
     //
-    export interface LocalizationStringsApi {
+    interface LocalizationStringsApi {
         getLanguage(): string;
 
         setLanguage(language: string): void;
@@ -56,5 +56,5 @@ declare module 'react-native-localization' {
         new<T>(globalStrings: GlobalStrings<T>): LocalizationStringsApi & T;
     }
     const LocalizedStrings: ILocalizedStrings;
-    export default LocalizedStrings;
+    export = LocalizedStrings;
 }


### PR DESCRIPTION
**HELLO!**
I noticed 2 problems when using this module alongside with TypeScript:
* You'd have to hard cast the result of `new LocalizedStrings(...)` to use the API methods
* You lose all the types of `T` (of `GlobalStrings<T>`) when you, again, instantiate `LocalizedStrings`. Losing a lot of TypeScript flexibility

So I fixed these problems, but with a side effect: on TypeScript you'd have to import in a different way:
```typescript
import LocalizedString = require("react-native-localization");
```
PS: I also removed some unnecessary commentaries. Due to the modifications, they are no longer useful