### PR TITLE
Re-export GlobalStrings and LocalizationStringsApi

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,10 +127,25 @@ Then use the `strings` object literal directly in the render method accessing th
 The first language is considered the default one, so if a translation is missing for the selected language, the default one is shown and a line is written to the log as a reminder.
 
 ## Typescript
-When using ts you should import the library like this:
+For TypeScript, your `tsconfig.json` should be something like this:
+```json
+{
+    "compilerOptions": {
+        "target": "es2015",
+        "module": "es2015",
+        "jsx": "react-native",
+        "moduleResolution": "node",
+        "allowSyntheticDefaultImports": true
+    }
+}
+```
+
+Where `"module": "es2015"` is the most important setting for being able to import the module properly.
+
+Import should be done like this:
 
 ```ts
-import LocalizedString = require("react-native-localization");
+import LocalizedString from "react-native-localization";
 ```
 
 ## API

--- a/lib/LocalizedStrings.d.ts
+++ b/lib/LocalizedStrings.d.ts
@@ -4,7 +4,7 @@ declare module 'react-native-localization' {
     //
     // strings.getLanguage()
     //
-    interface LocalizationStringsApi {
+    export interface LocalizationStringsApi {
         getLanguage(): string;
 
         setLanguage(language: string): void;
@@ -41,7 +41,7 @@ declare module 'react-native-localization' {
     //          world: "le monde"
     //      }
     //  }
-    interface GlobalStrings<T> {
+    export interface GlobalStrings<T> {
         [language: string]: T;
     }
 
@@ -56,5 +56,5 @@ declare module 'react-native-localization' {
         new<T>(globalStrings: GlobalStrings<T>): LocalizationStringsApi & T;
     }
     const LocalizedStrings: ILocalizedStrings;
-    export = LocalizedStrings;
+    export default LocalizedStrings;
 }


### PR DESCRIPTION
Make LocalizedStrings default export so we don't have to use `require`