### PR TITLE
Main Queue Setup Warning

### DIFF
--- a/ReactLocalization.m
+++ b/ReactLocalization.m
@@ -76,4 +76,9 @@ RCT_EXPORT_METHOD(getLanguage:(RCTResponseSenderBlock)callback){
 {
     return @{ @"language": [self getCurrentLanguage]};
 }
+
++(BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
 @end


### PR DESCRIPTION
adds requiresMainQueueSetup `true` to prevent future break and eliminates warning