### PR TITLE
Better setup for android build version.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.0"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         ndk {
@@ -15,6 +15,4 @@ android {
     }
 }
 
-dependencies {
-    compile 'com.facebook.react:react-native:0.11.+'
-}
+dependencies { compile 'com.facebook.react:react-native:+' }


### PR DESCRIPTION
React Native now has its project set up with default build version of android`s sdk. Set android build version to that of `rootProjet``s to prevent from build failing cause of version mismatch.