### PR TITLE
Remove Gradle warning

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,4 +15,4 @@ android {
     }
 }
 
-dependencies { compile 'com.facebook.react:react-native:+' }
+dependencies { implementation 'com.facebook.react:react-native:+' }


### PR DESCRIPTION
- WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html