### PR TITLE
Replace deprecated 'compile' gradle configuration with 'implementation'

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,4 +15,4 @@ android {
     }
 }
 
-dependencies { compile 'com.facebook.react:react-native:+' }
+dependencies { implementation 'com.facebook.react:react-native:+' }


### PR DESCRIPTION
According to [ReactNative@0.57](https://github.com/react-native-community/react-native-releases/blob/master/CHANGELOG.md#057) default gradle version is now `4.4`.