### PR TITLE
Tolerate that buildToolsVersion is not set in rootProject

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,12 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
+    buildToolsVersion safeExtGet("buildToolsVersion", "26.0.3")
 
     defaultConfig {
         minSdkVersion rootProject.ext.minSdkVersion


### PR DESCRIPTION
Do not assume that buildToolsVersion is set on root project, as this is commonly not done
for versions of Android Gradle Plugin > 3.1.4 (which uses a default version for that version of the plugin).
=> Use a safe get, with a fallback.