### PR TITLE
Use packaged build tool versions in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,21 @@
 apply plugin: 'com.android.library'
 
+def DEFAULT_COMPILE_SDK_VERSION             = 26
+def DEFAULT_BUILD_TOOLS_VERSION             = "26.0.3"
+def DEFAULT_MIN_SDK_VERSION                 = 16
+def DEFAULT_TARGET_SDK_VERSION              = 26
+
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion rootProject.ext.compileSdkVersion
-    buildToolsVersion rootProject.ext.buildToolsVersion
+    compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
+    buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
 
     defaultConfig {
-        minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)
+        targetSdkVersion safeExtGet('targetSdkVersion', DEFAULT_TARGET_SDK_VERSION)
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
### What happens right now if build tool versions are not set

```
FAILURE: Build failed with an exception.

* Where:
Build file '/my_android_app/node_modules/react-native-localization/android/build.gradle' line: 4

* What went wrong:
A problem occurred evaluating project ':react-native-localization'.
> Cannot get property 'compileSdkVersion' on extra properties extension as it does not exist
```

Note that our android project is a non-standard setup and was not created using `react-native init`/`expo init`.

### What this PR does

Avoid hardocoded versions for build tools as recommended by
react-native - [react-native-community/react-native-releases:CHANGELOG.md@`master`#known-issues](https://github.com/react-native-community/react-native-releases/blob/master/CHANGELOG.md#known-issues)
Also see [react-native-community/react-native-linear-gradient:android/build.gradle@`v2.5.4`](https://github.com/react-native-community/react-native-linear-gradient/blob/v2.5.4/android/build.gradle)

Note that this builds on #147 