### PR TITLE
.js files are not source files that Xcode can compile

### DIFF
--- a/ReactNativeLocalization.podspec
+++ b/ReactNativeLocalization.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.dependency 'React'
 
   s.preserve_paths      = 'CHANGELOG.md', 'LICENSE', 'package.json'
-  s.source_files        = '**/*.{h,m}', 'lib/LocalizedStrings.js'
+  s.source_files        = '**/*.{h,m}'
   s.exclude_files       = 'android/**/*'
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-localization",
-  "version": "2.1.1",
+  "version": "2.1.1-pss",
   "description": "Simple module to localize the ReactNative interface",
   "main": "./lib/LocalizedStrings.js",
   "types": "./lib/LocalizedStrings.d.ts",


### PR DESCRIPTION
By including the .js file in the list of source_files in the podspec, users of this library see the following warning:

no rule to process file <path>/lib/LocalizedStrings.js of type 'sourcecode.javascript' for architecture x86_64 (in target 'ReactNativeLocalization')

Thus, I have removed the .js file from the list of source code files