### PR TITLE
Correct React Native peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "babel-preset-env": "^1.6.1"
   },
   "peerDependencies": {
-    "react-native": "^0.64",
-    "react-native-windows": "0.64.5"
+    "react-native": ">0.64",
+    "react-native-windows": ">0.64"
   }
 }


### PR DESCRIPTION
This fixes issues resolving peer dependencies for newer versions of react-native, with newer node versions this will fail on later react-native versions without `` --force, or --legacy-peer-deps``