### PR TITLE
Resolve some unmet peer dependency warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-preset-env": "^1.6.1"
   },
   "peerDependencies": {
+    "react": ">16.0.0",
     "react-native": ">0.64",
     "react-native-windows": ">0.64"
   },

--- a/package.json
+++ b/package.json
@@ -39,5 +39,10 @@
   "peerDependencies": {
     "react-native": ">0.64",
     "react-native-windows": ">0.64"
+  },
+  "peerDependenciesMeta": {
+    "react-native-windows": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
This pull request resolves the following peer dependency warnings:

1. Our project had an unmet peer dependency on `react-native-windows`—not every React Native app targets Windows so this should an optional peer dependency. 
2. This project didn't provide `react` as request by the `react-localization` dependency, breaking the requirement:

    ```sh
    "react": "^17.0.0 || ^16.0.0 || ^15.6.0"
   ```

    Adding `"react": ">16.0.0"` as a peer dependency resolves this warning. Note: the required version is >16.0.0 and not > 15.6.0 because `react-localization` has the following dev dependency specification for `react`: 

    ```sh
    "react": "^16.0.0"
   ```
