### PR TITLE
Fix failing build on iOS

### DIFF
--- a/ios/ReactLocalization.h
+++ b/ios/ReactLocalization.h
@@ -23,13 +23,8 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIDevice.h>
-#if __has_include("RCTBridgeModule.h")
-#import "RCTBridgeModule.h"
-#import "RCTLog.h"
-#else
 #import <React/RCTBridgeModule.h>
 #import <React/RCTLog.h>
-#endif
 @interface ReactLocalization : NSObject<RCTBridgeModule>
 
 @end


### PR DESCRIPTION
This fixes #214 for me. The problem happens after upgrading to Expo SDK 44, not sure why.